### PR TITLE
Improve portability for CodePen previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Sipariş Paneli Önizleme
+
+Bu depo, yerel olarak çalışan bir portföy panelinin statik dosyalarını içerir. Kodun hem yerel geliştirmede hem de CodePen gibi çevrimiçi editörlerde çalışması için gerekli adımlar aşağıdadır.
+
+## Yerel Önizleme
+1. Depo klasöründe basit bir HTTP sunucusu başlatın:
+   ```bash
+   python -m http.server 8000
+   ```
+2. Tarayıcıda `http://localhost:8000/index.html` adresini açın.
+3. Portföy verileri `data/mock-data.json` dosyasından alınır; sunucu çalışmazsa betik otomatik olarak yerleşik örnek verileri kullanır.
+
+## CodePen / Çevrimiçi Editör Kullanımı
+### Hızlı Başlangıç
+- `codepen.html` dosyasını açın ve içeriğini CodePen'in **HTML** paneline tek seferde yapıştırın.
+- Harici bağımlılıklar dosyada zaten CDN üzerinden tanımlıdır. Ek script eklemenize gerek yoktur.
+
+### Alternatif Yöntem
+1. **HTML paneli:** `index.html` dosyasındaki `<body>` içeriğini kopyalayın.
+2. **CSS paneli:** `style.css` dosyasının tamamını yapıştırın.
+3. **JS paneli:** `script.js` dosyasının tamamını yapıştırın.
+4. **Settings → JS** bölümünden şu CDN adreslerini ekleyin (sırasıyla):
+   - `https://cdn.jsdelivr.net/npm/chart.js`
+   - `https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0`
+   - `https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js`
+5. `mock-data.json` dosyasını yüklemeyi unutsanız bile betik varsayılan örnek veriye döner; panel boş kalmaz.
+
+## Bilinen Dayanıklılık Önlemleri
+- Chart.js veya veri etiketi eklentileri yüklenemezse grafik alanı gizlenir ve kullanıcıya bilgilendirici mesaj gösterilir.
+- Profil görseli bulunamazsa otomatik olarak 60x60 boyutlarında bir yer tutucu görüntü kullanılır.
+- Tüm dinamik panellerde veri olmadığı durumlar için açıklayıcı geri bildirim mesajları gösterilir.
+
+## Testler
+Depoda otomatik test altyapısı yoktur, ancak sözdizimi kontrolleri için aşağıdaki komutları kullanabilirsiniz:
+```bash
+node --check script.js
+python -m json.tool data/mock-data.json > /dev/null
+```

--- a/codepen.html
+++ b/codepen.html
@@ -1,3 +1,178 @@
+<!DOCTYPE html>
+<html lang="tr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Portföy Panosu</title>
+    <style>
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap');
+:root{--bg-color:#121212;--surface-color:#1E1E1E;--primary-text:#E0E0E0;--secondary-text:#A0A0A0;--green:#26A69A;--red:#EF5350;--border-color:#333333;--gold:#FFD700;--blue:#03A9F4;--highlight-color:#2a2a2a;}
+body{font-family:'Roboto',sans-serif;background-color:var(--bg-color);color:var(--primary-text);margin:0;padding:20px;transition: background-color 0.3s, color 0.3s;}
+body.light-theme{--bg-color:#F0F2F5;--surface-color:#FFFFFF;--primary-text:#1C1E21;--secondary-text:#606770;--border-color:#DADDE1;--highlight-color:#EBF5FF;}
+body.modal-open{overflow:hidden;}
+#particles-js{position:fixed;width:100%;height:100%;top:0;left:0;z-index:-1;}
+.container{max-width:1400px;margin:0 auto;background-color:var(--surface-color);padding:25px 40px;border-radius:12px;border:1px solid var(--border-color);box-shadow:0 10px 30px rgba(0,0,0,0.1);transition: background-color 0.3s, border-color 0.3s;}
+.ticker-wrap{width:100%;overflow:hidden;background-color:var(--bg-color);padding:10px 0;border-bottom:1px solid var(--border-color);margin-bottom:25px;transition: background-color 0.3s, border-color 0.3s;}
+.secondary-ticker{margin-top:30px;margin-bottom:0;border-top:1px solid var(--border-color);border-bottom:none;font-size:0.9em;}
+.ticker-move{display:inline-block;white-space:nowrap;animation:scroll-left 40s linear infinite;}
+.ticker-item{display:inline-block;margin:0 25px;font-size:1em;color:var(--secondary-text);}
+.ticker-item .symbol{color:var(--primary-text);font-weight:bold;}
+@keyframes scroll-left{0%{transform:translateX(100%);} 100%{transform:translateX(-100%);}}
+header .header-top{display:flex;justify-content:space-between;align-items:center;padding-bottom:15px;gap:15px;}
+header .profile{display:flex;align-items:center;gap:15px;}
+header .profile img{width:60px;height:60px;border-radius:50%;border:2px solid var(--blue);object-fit:cover;background-color:#333;}
+.header-actions{display:flex;align-items:center;gap:10px;}
+.summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:20px;margin:25px 0;text-align:left;}
+.summary.is-updated .summary-item{animation:refresh-pulse .6s ease;}
+.summary-item{background-color:var(--bg-color);padding:20px;border-radius:8px;border:1px solid var(--border-color);transition: all .2s ease-in-out;}
+.summary-item:hover{transform:translateY(-5px);box-shadow:0 8px 16px rgba(0,0,0,0.2);}
+.summary-item h2{font-size:1em;color:var(--secondary-text);margin:0 0 10px 0;font-weight:400;}
+.summary-item p{font-size:1.75em;font-weight:700;margin:0;}
+.hedef-deger{color:var(--gold);}
+.performance-metric{font-size:1.5em !important;color:var(--primary-text);}
+.performance-metric span{font-size:.7em;color:var(--secondary-text);margin-left:8px;}
+.main-content{display:flex;gap:30px;margin-top:20px;}
+.portfolio-section{flex:3;}
+.market-data-panel{flex:1;background-color:var(--bg-color);padding:20px;border-radius:8px;border:1px solid var(--border-color); transition: background-color 0.3s, border-color 0.3s;}
+.chart-container .chart-fallback{margin-top:15px;color:var(--secondary-text);font-style:italic;}
+main h2,.market-data-panel h2{color:var(--primary-text);border-bottom:1px solid var(--border-color);padding-bottom:10px;margin-top:0;}
+table{width:100%;border-collapse:collapse;font-size:1em;table-layout:fixed;}
+th,td{padding:12px 16px;border-bottom:1px solid var(--border-color);text-align:left;vertical-align:middle;word-wrap:break-word;}
+th:nth-child(2),td:nth-child(2){width:10%;}
+tbody tr{transition:background-color .2s ease;}
+tbody tr:nth-child(even){background-color:rgba(0,0,0,0.2);}
+body.light-theme tbody tr:nth-child(even){background-color: #F7F8FA;}
+tbody tr:hover,tbody tr.highlight{background-color:var(--highlight-color);}
+.positive{color:var(--green);font-weight:500;}
+.negative{color:var(--red);font-weight:500;}
+.bottom-content{display:flex;gap:30px;margin-top:30px;border-top:1px solid var(--border-color);padding-top:20px;}
+.analysis-panel{flex:1;}
+.news-panel{flex:2;padding-right:20px;margin-top:40px;}
+#news-list { list-style: none; padding: 0; position: relative; height: 320px; overflow: hidden; }
+#news-list li { background-color: var(--bg-color); padding: 10px; border-radius: 5px; margin-bottom: 15px; transition: opacity 0.8s ease-in-out, transform 0.8s ease-in-out; }
+#news-list li.fade-out { opacity: 0; transform: translateY(-20px); }
+#news-list h3 { margin: 0 0 5px 0; color: var(--primary-text); font-size: 1em; }
+.analysis-container{display:flex;gap:20px;}
+.analysis-side{flex:1;background-color:var(--bg-color);padding:15px;border-radius:8px;}
+.analysis-side h3{margin-top:0;text-align:center;color:var(--secondary-text);}
+.analysis-side ul{list-style:none;padding:0;margin:0;}
+.analysis-side li{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;font-size:.9em; padding: 4px; border-radius: 3px;}
+.flash-green{animation:flash-green .8s ease-out;}
+.flash-red{animation:flash-red .8s ease-out;}
+@keyframes flash-green{0%{background-color:rgba(38,166,154,0.5);} 100%{background-color:transparent;}}
+@keyframes flash-red{0%{background-color:rgba(239,83,80,0.5);} 100%{background-color:transparent;}}
+.quote-container{text-align:center;margin-top:40px;padding:20px;border-top:1px solid var(--border-color);}
+footer{text-align:center;margin-top:10px;color:var(--secondary-text);font-size:.9em;}
+.signature{color:#444;font-family:'Georgia',serif;font-style:italic;font-size:1.1em;margin-bottom:15px;transition:color .3s ease;}
+body.light-theme .signature{color:#ccc;}
+.signature:hover{color:#666;}
+body.light-theme .signature:hover{color:#aaa;}
+.icon-button{background:0 0;border:1px solid var(--border-color);color:var(--secondary-text);font-size:1.35em;width:45px;height:45px;border-radius:50%;cursor:pointer;transition:all .2s ease;display:inline-flex;align-items:center;justify-content:center;}
+.icon-button:hover{background-color:var(--border-color);color:var(--primary-text);}
+.icon-button:disabled,.icon-button[aria-disabled="true"]{cursor:not-allowed;opacity:0.6;transform:none;}
+.icon-button.is-loading::after{content:"";width:18px;height:18px;border:2px solid var(--secondary-text);border-top-color:var(--primary-text);border-radius:50%;animation:spin 1s linear infinite;}
+.icon-button.is-loading{color:transparent;}
+.header-actions #settings-btn:hover{transform:rotate(45deg);}
+.icon-button:focus-visible,.close-btn:focus-visible,#theme-toggle:focus-visible{outline:2px solid var(--blue);outline-offset:2px;}
+.modal-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background-color:rgba(0,0,0,.7);display:flex;justify-content:center;align-items:center;z-index:1000;}
+.modal-overlay[hidden]{display:none;}
+.modal-content{background-color:var(--surface-color);padding:30px 40px;border-radius:12px;border:1px solid var(--border-color);width:90%;max-width:500px;position:relative;}
+.close-btn{position:absolute;top:10px;right:15px;background:0 0;border:none;font-size:2em;color:var(--secondary-text);cursor:pointer;}
+#theme-toggle{padding:10px 20px;border:none;border-radius:4px;background-color:var(--blue);color:#fff;font-weight:700;cursor:pointer;}
+.analysis-side ul[aria-live="polite"]{min-height:160px;}
+.visually-hidden{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+@keyframes refresh-pulse{0%{box-shadow:0 0 0 0 rgba(3,169,244,0.55);}100%{box-shadow:0 0 0 20px rgba(3,169,244,0);}}
+@keyframes spin{to{transform:rotate(360deg);}}
+@media (prefers-reduced-motion: reduce){
+    .ticker-move{animation:none;}
+    #news-list li{transition:none;}
+    .icon-button.is-loading::after{animation:none;}
+    .summary.is-updated .summary-item{animation:none;}
+}
+@media(max-width:992px){.main-content,.bottom-content{flex-direction:column;}}
+@media(max-width:576px){body{padding:10px;} .container{padding:15px;}.summary-item p{font-size:1.5em;}}
+
+</style>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
+</head>
+<body class="dark-theme">
+    <div id="particles-js"></div>
+    <div class="container">
+        <div class="ticker-wrap">
+            <div class="ticker-move" id="ticker-move" role="marquee" aria-live="polite" aria-label="Güncel piyasa verileri"></div>
+        </div>
+        <header>
+            <div class="header-top">
+                <div class="profile"><img src="profil.jpg" alt="Ali Karapıçak profil fotoğrafı" onerror="this.onerror=null;this.src='https://via.placeholder.com/60x60.png?text=AK';"><h1 class="profile-name">Borsa Portföyü</h1></div>
+                <div class="header-actions">
+                    <button id="refresh-btn" class="icon-button" aria-label="Verileri yenile" title="Verileri yenile">⟳</button>
+                    <button id="settings-btn" class="icon-button" aria-label="Ayarlar" aria-haspopup="dialog" aria-expanded="false" aria-controls="settings-modal">⚙️</button>
+                </div>
+            </div>
+            <div class="summary">
+                <div class="summary-item"><h2>Toplam Değer</h2><p id="toplam-deger">Hesaplanıyor...</p></div>
+                <div class="summary-item"><h2>Toplam Kâr/Zarar</h2><p id="toplam-kar-zarar">Hesaplanıyor...</p></div>
+                <div class="summary-item"><h2>1 Yıllık Hedef (%40 Artış)</h2><p id="bir-yillik-hedef" class="hedef-deger">Hesaplanıyor...</p></div>
+                <div class="summary-item"><h2>Geleceğin Yıldızı (1Y Fiyat Hedefi)</h2><p id="best-performer" class="performance-metric">Hesaplanıyor...</p></div>
+                <div class="summary-item"><h2>Gizli Hazine (Dengeleme Hedefi)</h2><p id="smallest-position" class="performance-metric">Hesaplanıyor...</p></div>
+            </div>
+            <p id="data-status" class="visually-hidden" role="status" aria-live="polite"></p>
+        </header>
+        <div class="main-content">
+            <main class="portfolio-section">
+                <h2>Varlıklarım</h2>
+                <table id="hisse-tablosu">
+                    <thead>
+                        <tr>
+                            <th>Hisse</th><th>Ağırlık</th><th>Lot</th><th>Maliyet</th><th>Anlık Fiyat</th><th>Toplam Değer</th><th>Kâr/Zarar</th><th>K/Z (%)</th>
+                        </tr>
+                    </thead>
+                    <tbody id="hisse-listesi"></tbody>
+                </table>
+                 <section class="news-panel">
+                    <h2>Piyasa Haberleri</h2>
+                    <ul id="news-list" aria-live="polite" aria-atomic="false"></ul>
+                </section>
+            </main>
+            <aside class="market-data-panel">
+                <div class="chart-container"><h2>Portföy Dağılımı</h2><canvas id="portfolioChart"></canvas></div>
+                <h2>Piyasa Verileri</h2>
+                <div class="market-category"><h3>En Çok Yükselenler</h3><ul id="top-gainers-list"></ul></div>
+                <div class="market-category"><h3>En Çok Düşenler</h3><ul id="top-losers-list"></ul></div>
+                <div class="market-category"><h3>Hacmi En Yüksekler</h3><ul id="top-volume-list"></ul></div>
+            </aside>
+        </div>
+        <div class="bottom-content">
+            <section class="analysis-panel">
+                <h2>Anlık Takas Analizi (Canlı Veri)</h2>
+                <div class="analysis-container">
+                    <div class="analysis-side"><h3>Alıcı Kurumlar</h3><ul id="buyers-list" aria-live="polite" aria-atomic="true"></ul></div>
+                    <div class="analysis-side"><h3>Satıcı Kurumlar</h3><ul id="sellers-list" aria-live="polite" aria-atomic="true"></ul></div>
+                </div>
+            </section>
+        </div>
+        <div class="quote-container"><p id="quote-text" aria-live="polite" aria-atomic="true"></p><p id="quote-author"></p></div>
+        <div class="ticker-wrap secondary-ticker">
+            <div class="ticker-move" id="secondary-ticker-move" role="marquee" aria-live="polite" aria-label="Döviz ve değerli maden fiyatları"></div>
+        </div>
+        <footer>
+            <div class="signature">Broker Ali Karapıçak</div>
+            <p>Son Güncelleme: <span id="son-guncelleme"></span></p>
+        </footer>
+    </div>
+    <div id="settings-modal" class="modal-overlay" role="presentation" hidden aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="settings-title" tabindex="-1">
+            <button id="close-modal-btn" class="close-btn" aria-label="Kapat" data-modal-close>&times;</button>
+            <h2 id="settings-title">Ayarlar</h2>
+            <div class="setting-item">
+                <label for="theme-toggle">Site Teması</label>
+                <button id="theme-toggle" data-modal-initial-focus>Açık/Koyu Tema Değiştir</button>
+            </div>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
+    <script>
 // Kodun tamamını, daha temiz ve global değişkenlerden arındırılmış bir yapıya soktum.
 (function() {
     const defaultData = {
@@ -825,3 +1000,7 @@
         });
     }
 })(); // Kodun tamamını sarmalayan ve global scope'u kirletmeyen yapı
+
+</script>
+</body>
+</html>

--- a/data/mock-data.json
+++ b/data/mock-data.json
@@ -1,0 +1,59 @@
+{
+  "portfolio": [
+    { "sembol": "SMARTG", "lot": 8501, "maliyet": 40.75, "anlikFiyat": 30.8 },
+    { "sembol": "ARDYZ", "lot": 3568, "maliyet": 36.04, "anlikFiyat": 28.1 },
+    { "sembol": "KCAER", "lot": 5601, "maliyet": 14.77, "anlikFiyat": 14.63 },
+    { "sembol": "SASA", "lot": 11290, "maliyet": 3.32, "anlikFiyat": 4.2 }
+  ],
+  "quotes": [
+    { "soz": "Borsa, sabırsız olanın sabırlı olana para aktardığı bir mekanizmadır.", "yazar": "Warren Buffett" },
+    { "soz": "Ne zaman satacağını bilmeyen, ne zaman alacağını da bilemez.", "yazar": "André Kostolany" }
+  ],
+  "marketData": {
+    "yukselenler": [
+      { "sembol": "TUPRS", "degisim": "+5.67%" },
+      { "sembol": "THYAO", "degisim": "+4.12%" }
+    ],
+    "dusenler": [
+      { "sembol": "KRDMD", "degisim": "-2.50%" },
+      { "sembol": "HEKTS", "degisim": "-2.88%" }
+    ],
+    "hacimliler": [
+      { "sembol": "GARAN", "hacim": "2.1 Milyar ₺" }
+    ]
+  },
+  "news": [
+    {
+      "baslik": "Yenilenebilir Enerji Raporu: Güneş Panelleri Yatırımları Zirvede",
+      "ozet": "Uluslararası Enerji Ajansı'nın yayımladığı son rapora göre, artan enerji talebi ve teşvikler sayesinde güneş enerjisi santrallerine (GES) yapılan yatırımların rekor seviyeye ulaştığı belirtildi.",
+      "tarih": "22 Eylül 2025"
+    },
+    {
+      "baslik": "BIST 100 Günü Yükselişle Tamamladı",
+      "ozet": "Borsa İstanbul'da BIST 100 endeksi, günü %1,25 değer kazancıyla 9.150 puandan tamamladı...",
+      "tarih": "22 Eylül 2025"
+    },
+    {
+      "baslik": "Teknoloji Sektörü İçin Yeni Teşvik Paketi Yolda",
+      "ozet": "Sanayi ve Teknoloji Bakanlığı'nın, yerli yazılım üreticilerini destekleyecek yeni bir teşvik paketi üzerinde çalıştığı bildirildi...",
+      "tarih": "21 Eylül 2025"
+    }
+  ],
+  "brokers": [
+    "İŞ YATIRIM",
+    "BANK OF AMERICA",
+    "GARANTİ BBVA",
+    "YAPI KREDİ",
+    "AK YATIRIM",
+    "ÜNLÜ & CO",
+    "TEB YATIRIM",
+    "HALK YATIRIM",
+    "ODEA BANK",
+    "PHILLIPCAPITAL"
+  ],
+  "financialData": [
+    { "sembol": "GRAM ALTIN", "fiyat": "2.450,78 ₺", "degisim": "+0.25%", "sinif": "positive" },
+    { "sembol": "ONS ALTIN", "fiyat": "2.330,45 $", "degisim": "-0.15%", "sinif": "negative" },
+    { "sembol": "USD/TRY", "fiyat": "32,85 ₺", "degisim": "+0.05%", "sinif": "positive" }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -8,16 +8,19 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-datalabels@2.0.0"></script>
 </head>
-<body>
+<body class="dark-theme">
     <div id="particles-js"></div>
     <div class="container">
         <div class="ticker-wrap">
-            <div class="ticker-move" id="ticker-move"></div>
+            <div class="ticker-move" id="ticker-move" role="marquee" aria-live="polite" aria-label="Güncel piyasa verileri"></div>
         </div>
         <header>
             <div class="header-top">
-                <div class="profile"><img src="profil.jpg" alt="Ali Karapıçak profil fotoğrafı"><h1 class="profile-name">Borsa Portföyü</h1></div>
-                <button id="settings-btn" class="settings-btn" aria-label="Ayarlar">⚙️</button>
+                <div class="profile"><img src="profil.jpg" alt="Ali Karapıçak profil fotoğrafı" onerror="this.onerror=null;this.src='https://via.placeholder.com/60x60.png?text=AK';"><h1 class="profile-name">Borsa Portföyü</h1></div>
+                <div class="header-actions">
+                    <button id="refresh-btn" class="icon-button" aria-label="Verileri yenile" title="Verileri yenile">⟳</button>
+                    <button id="settings-btn" class="icon-button" aria-label="Ayarlar" aria-haspopup="dialog" aria-expanded="false" aria-controls="settings-modal">⚙️</button>
+                </div>
             </div>
             <div class="summary">
                 <div class="summary-item"><h2>Toplam Değer</h2><p id="toplam-deger">Hesaplanıyor...</p></div>
@@ -26,6 +29,7 @@
                 <div class="summary-item"><h2>Geleceğin Yıldızı (1Y Fiyat Hedefi)</h2><p id="best-performer" class="performance-metric">Hesaplanıyor...</p></div>
                 <div class="summary-item"><h2>Gizli Hazine (Dengeleme Hedefi)</h2><p id="smallest-position" class="performance-metric">Hesaplanıyor...</p></div>
             </div>
+            <p id="data-status" class="visually-hidden" role="status" aria-live="polite"></p>
         </header>
         <div class="main-content">
             <main class="portfolio-section">
@@ -40,7 +44,7 @@
                 </table>
                  <section class="news-panel">
                     <h2>Piyasa Haberleri</h2>
-                    <ul id="news-list"></ul>
+                    <ul id="news-list" aria-live="polite" aria-atomic="false"></ul>
                 </section>
             </main>
             <aside class="market-data-panel">
@@ -55,27 +59,27 @@
             <section class="analysis-panel">
                 <h2>Anlık Takas Analizi (Canlı Veri)</h2>
                 <div class="analysis-container">
-                    <div class="analysis-side"><h3>Alıcı Kurumlar</h3><ul id="buyers-list"></ul></div>
-                    <div class="analysis-side"><h3>Satıcı Kurumlar</h3><ul id="sellers-list"></ul></div>
+                    <div class="analysis-side"><h3>Alıcı Kurumlar</h3><ul id="buyers-list" aria-live="polite" aria-atomic="true"></ul></div>
+                    <div class="analysis-side"><h3>Satıcı Kurumlar</h3><ul id="sellers-list" aria-live="polite" aria-atomic="true"></ul></div>
                 </div>
             </section>
         </div>
-        <div class="quote-container"><p id="quote-text"></p><p id="quote-author"></p></div>
+        <div class="quote-container"><p id="quote-text" aria-live="polite" aria-atomic="true"></p><p id="quote-author"></p></div>
         <div class="ticker-wrap secondary-ticker">
-            <div class="ticker-move" id="secondary-ticker-move"></div>
+            <div class="ticker-move" id="secondary-ticker-move" role="marquee" aria-live="polite" aria-label="Döviz ve değerli maden fiyatları"></div>
         </div>
         <footer>
             <div class="signature">Broker Ali Karapıçak</div>
             <p>Son Güncelleme: <span id="son-guncelleme"></span></p>
         </footer>
     </div>
-    <div id="settings-modal" class="modal-overlay" style="display: none;">
-        <div class="modal-content">
-            <button id="close-modal-btn" class="close-btn" aria-label="Kapat">&times;</button>
-            <h2>Ayarlar</h2>
+    <div id="settings-modal" class="modal-overlay" role="presentation" hidden aria-hidden="true">
+        <div class="modal-content" role="dialog" aria-modal="true" aria-labelledby="settings-title" tabindex="-1">
+            <button id="close-modal-btn" class="close-btn" aria-label="Kapat" data-modal-close>&times;</button>
+            <h2 id="settings-title">Ayarlar</h2>
             <div class="setting-item">
                 <label for="theme-toggle">Site Teması</label>
-                <button id="theme-toggle">Açık/Koyu Tema Değiştir</button>
+                <button id="theme-toggle" data-modal-initial-focus>Açık/Koyu Tema Değiştir</button>
             </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
 :root{--bg-color:#121212;--surface-color:#1E1E1E;--primary-text:#E0E0E0;--secondary-text:#A0A0A0;--green:#26A69A;--red:#EF5350;--border-color:#333333;--gold:#FFD700;--blue:#03A9F4;--highlight-color:#2a2a2a;}
 body{font-family:'Roboto',sans-serif;background-color:var(--bg-color);color:var(--primary-text);margin:0;padding:20px;transition: background-color 0.3s, color 0.3s;}
 body.light-theme{--bg-color:#F0F2F5;--surface-color:#FFFFFF;--primary-text:#1C1E21;--secondary-text:#606770;--border-color:#DADDE1;--highlight-color:#EBF5FF;}
+body.modal-open{overflow:hidden;}
 #particles-js{position:fixed;width:100%;height:100%;top:0;left:0;z-index:-1;}
 .container{max-width:1400px;margin:0 auto;background-color:var(--surface-color);padding:25px 40px;border-radius:12px;border:1px solid var(--border-color);box-shadow:0 10px 30px rgba(0,0,0,0.1);transition: background-color 0.3s, border-color 0.3s;}
 .ticker-wrap{width:100%;overflow:hidden;background-color:var(--bg-color);padding:10px 0;border-bottom:1px solid var(--border-color);margin-bottom:25px;transition: background-color 0.3s, border-color 0.3s;}
@@ -10,10 +11,12 @@ body.light-theme{--bg-color:#F0F2F5;--surface-color:#FFFFFF;--primary-text:#1C1E
 .ticker-item{display:inline-block;margin:0 25px;font-size:1em;color:var(--secondary-text);}
 .ticker-item .symbol{color:var(--primary-text);font-weight:bold;}
 @keyframes scroll-left{0%{transform:translateX(100%);} 100%{transform:translateX(-100%);}}
-header .header-top{display:flex;justify-content:space-between;align-items:center;padding-bottom:15px;}
+header .header-top{display:flex;justify-content:space-between;align-items:center;padding-bottom:15px;gap:15px;}
 header .profile{display:flex;align-items:center;gap:15px;}
 header .profile img{width:60px;height:60px;border-radius:50%;border:2px solid var(--blue);object-fit:cover;background-color:#333;}
+.header-actions{display:flex;align-items:center;gap:10px;}
 .summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:20px;margin:25px 0;text-align:left;}
+.summary.is-updated .summary-item{animation:refresh-pulse .6s ease;}
 .summary-item{background-color:var(--bg-color);padding:20px;border-radius:8px;border:1px solid var(--border-color);transition: all .2s ease-in-out;}
 .summary-item:hover{transform:translateY(-5px);box-shadow:0 8px 16px rgba(0,0,0,0.2);}
 .summary-item h2{font-size:1em;color:var(--secondary-text);margin:0 0 10px 0;font-weight:400;}
@@ -24,6 +27,7 @@ header .profile img{width:60px;height:60px;border-radius:50%;border:2px solid va
 .main-content{display:flex;gap:30px;margin-top:20px;}
 .portfolio-section{flex:3;}
 .market-data-panel{flex:1;background-color:var(--bg-color);padding:20px;border-radius:8px;border:1px solid var(--border-color); transition: background-color 0.3s, border-color 0.3s;}
+.chart-container .chart-fallback{margin-top:15px;color:var(--secondary-text);font-style:italic;}
 main h2,.market-data-panel h2{color:var(--primary-text);border-bottom:1px solid var(--border-color);padding-bottom:10px;margin-top:0;}
 table{width:100%;border-collapse:collapse;font-size:1em;table-layout:fixed;}
 th,td{padding:12px 16px;border-bottom:1px solid var(--border-color);text-align:left;vertical-align:middle;word-wrap:break-word;}
@@ -56,11 +60,27 @@ footer{text-align:center;margin-top:10px;color:var(--secondary-text);font-size:.
 body.light-theme .signature{color:#ccc;}
 .signature:hover{color:#666;}
 body.light-theme .signature:hover{color:#aaa;}
-.settings-btn{background:0 0;border:1px solid var(--border-color);color:var(--secondary-text);font-size:1.5em;width:45px;height:45px;border-radius:50%;cursor:pointer;transition:all .2s ease;}
-.settings-btn:hover{background-color:var(--border-color);color:var(--primary-text);transform:rotate(45deg);}
+.icon-button{background:0 0;border:1px solid var(--border-color);color:var(--secondary-text);font-size:1.35em;width:45px;height:45px;border-radius:50%;cursor:pointer;transition:all .2s ease;display:inline-flex;align-items:center;justify-content:center;}
+.icon-button:hover{background-color:var(--border-color);color:var(--primary-text);}
+.icon-button:disabled,.icon-button[aria-disabled="true"]{cursor:not-allowed;opacity:0.6;transform:none;}
+.icon-button.is-loading::after{content:"";width:18px;height:18px;border:2px solid var(--secondary-text);border-top-color:var(--primary-text);border-radius:50%;animation:spin 1s linear infinite;}
+.icon-button.is-loading{color:transparent;}
+.header-actions #settings-btn:hover{transform:rotate(45deg);}
+.icon-button:focus-visible,.close-btn:focus-visible,#theme-toggle:focus-visible{outline:2px solid var(--blue);outline-offset:2px;}
 .modal-overlay{position:fixed;top:0;left:0;width:100%;height:100%;background-color:rgba(0,0,0,.7);display:flex;justify-content:center;align-items:center;z-index:1000;}
+.modal-overlay[hidden]{display:none;}
 .modal-content{background-color:var(--surface-color);padding:30px 40px;border-radius:12px;border:1px solid var(--border-color);width:90%;max-width:500px;position:relative;}
 .close-btn{position:absolute;top:10px;right:15px;background:0 0;border:none;font-size:2em;color:var(--secondary-text);cursor:pointer;}
 #theme-toggle{padding:10px 20px;border:none;border-radius:4px;background-color:var(--blue);color:#fff;font-weight:700;cursor:pointer;}
+.analysis-side ul[aria-live="polite"]{min-height:160px;}
+.visually-hidden{position:absolute!important;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+@keyframes refresh-pulse{0%{box-shadow:0 0 0 0 rgba(3,169,244,0.55);}100%{box-shadow:0 0 0 20px rgba(3,169,244,0);}}
+@keyframes spin{to{transform:rotate(360deg);}}
+@media (prefers-reduced-motion: reduce){
+    .ticker-move{animation:none;}
+    #news-list li{transition:none;}
+    .icon-button.is-loading::after{animation:none;}
+    .summary.is-updated .summary-item{animation:none;}
+}
 @media(max-width:992px){.main-content,.bottom-content{flex-direction:column;}}
 @media(max-width:576px){body{padding:10px;} .container{padding:15px;}.summary-item p{font-size:1.5em;}}


### PR DESCRIPTION
## Summary
- add a placeholder fallback for the profile image and hide the doughnut chart when Chart.js is unavailable
- style the chart fallback state and guard chart rendering so the table remains usable without external plugins
- document CodePen setup instructions and include a standalone HTML bundle for quick copy-paste previews

## Testing
- node --check script.js
- python -m json.tool data/mock-data.json


------
https://chatgpt.com/codex/tasks/task_b_68d40ae7cc0c8324a8f8e1f09ea37506